### PR TITLE
fix: change some /themes dead links

### DIFF
--- a/test/inputs/demo.md
+++ b/test/inputs/demo.md
@@ -243,8 +243,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 preload: false

--- a/test/outputs/demo_config1.md
+++ b/test/outputs/demo_config1.md
@@ -245,8 +245,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 preload: false

--- a/test/outputs/demo_default.md
+++ b/test/outputs/demo_default.md
@@ -245,8 +245,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 preload: false

--- a/test/outputs/demo_noEmbed.md
+++ b/test/outputs/demo_noEmbed.md
@@ -243,8 +243,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 preload: false


### PR DESCRIPTION
### Description

This PR, as in https://github.com/slidevjs/slidev/pull/1886, suggests fixing some dead links in several files:
* https://sli.dev/themes/use or https://sli.dev/themes/use.html → https://sli.dev/guide/theme-addon#use-theme
* https://sli.dev/themes/gallery or https://sli.dev/themes/gallery.html → https://sli.dev/resources/theme-gallery

